### PR TITLE
MIST-150 Add Recursive bool parameter to SnapshotRequest

### DIFF
--- a/rpc/image.go
+++ b/rpc/image.go
@@ -51,8 +51,9 @@ type (
 
 	// SnapshotRequest is a snapshot request for the Storage sub-agent
 	SnapshotRequest struct {
-		Id   string `json:"id"`   // Volume ID
-		Dest string `json:"dest"` // Destination for clones, creates, etc
+		Id        string `json:"id"`        // Volume ID
+		Dest      string `json:"dest"`      // Destination for clones, creates, etc
+		Recursive bool   `json:"recursive"` // Recursively create snapshots for all descendent file systems
 	}
 
 	SnapshotResponse struct {


### PR DESCRIPTION
`zfs snapshot` takes a -r flag to recursively create snapshots of descendent datasets. Add a parameter to specify that during snapshot creation.
