### PR TITLE
MIST-222 Remove the hard ReadTimeout and WriteTimeout

### DIFF
--- a/http.go
+++ b/http.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	runtime_pprof "runtime/pprof"
 	"strings"
-	"time"
 
 	"github.com/bakins/net-http-recover"
 	"github.com/gorilla/handlers"
@@ -124,8 +123,6 @@ func Run(ctx *Context, address string) error {
 	s := &http.Server{
 		Addr:           address,
 		Handler:        r,
-		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 	return s.ListenAndServe()

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-	"time"
 
 	"github.com/bakins/net-http-recover"
 	"github.com/gorilla/handlers"
@@ -37,9 +36,7 @@ func NewServer(port uint) (*Server, error) {
 	s := &Server{
 		RpcServer: rpc.NewServer(),
 		HttpServer: &http.Server{
-			Addr:         fmt.Sprintf("127.0.0.1:%d", port),
-			ReadTimeout:  10 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			Addr: fmt.Sprintf("127.0.0.1:%d", port),
 		},
 		Router: mux.NewRouter(),
 	}


### PR DESCRIPTION
These timeouts are hard deadlines, not idle timeouts. The WriteTimeout was causing problems with large snapshot downloads being cut off in the middle. We'll have to figure out a more graceful way to handle timeouts later.
