### PR TITLE
Mist 246 - Updates to support lochness.Agent

### DIFF
--- a/guest.go
+++ b/guest.go
@@ -96,10 +96,11 @@ func createGuest(r *HttpRequest) *HttpErrorMessage {
 	if err != nil {
 		return r.NewError(err, 400)
 	}
-	if g.Id != "" {
-		return r.NewError(fmt.Errorf("id must not be set"), 400)
+	if g.Id != "" && uuid.Parse(g.Id) == nil {
+		return r.NewError(fmt.Errorf("id must be uuid"), 400)
+	} else {
+		g.Id = uuid.New()
 	}
-	g.Id = uuid.New()
 
 	// TODO: make sure it's actually unique
 	g.State = "create"

--- a/guest.go
+++ b/guest.go
@@ -96,8 +96,10 @@ func createGuest(r *HttpRequest) *HttpErrorMessage {
 	if err != nil {
 		return r.NewError(err, 400)
 	}
-	if g.Id != "" && uuid.Parse(g.Id) == nil {
-		return r.NewError(fmt.Errorf("id must be uuid"), 400)
+	if g.Id != "" {
+		if uuid.Parse(g.Id) == nil {
+			return r.NewError(fmt.Errorf("id must be uuid"), 400)
+		}
 	} else {
 		g.Id = uuid.New()
 	}

--- a/guest.go
+++ b/guest.go
@@ -125,6 +125,7 @@ func createGuest(r *HttpRequest) *HttpErrorMessage {
 			Action: action.Name,
 		}
 	}
+	r.ResponseWriter.Header().Set("X-Guest-Job-ID", pipeline.ID)
 	err = runner.Process(pipeline)
 	if err != nil {
 		return r.NewError(err, 500)
@@ -257,6 +258,7 @@ func (c *Chain) GuestActionWrapper(actionName string) http.HandlerFunc {
 				Action: action.Name,
 			}
 		}
+		r.ResponseWriter.Header().Set("X-Guest-Job-ID", pipeline.ID)
 		err = runner.Process(pipeline)
 		if err != nil {
 			return r.NewError(err, 500)

--- a/http.go
+++ b/http.go
@@ -92,6 +92,7 @@ func Run(ctx *Context, address string) error {
 	r.HandleFunc("/guests/{id}", chain.GuestRunnerWrapper(getGuest)).Methods("GET")
 	r.HandleFunc("/guests/{id}/jobs", chain.GuestRunnerWrapper(getLatestJobs)).Queries("limit", "{limit:[0-9]+}").Methods("GET")
 	r.HandleFunc("/guests/{id}/jobs", chain.GuestRunnerWrapper(getLatestJobs)).Methods("GET")
+	r.HandleFunc("/guests/{id}/jobs/{jobID}", chain.GuestRunnerWrapper(getJobStatus)).Methods("GET")
 	//r.HandleFunc("/guests/{id}", chain.GuestRunnerWrapper(deleteGuest)).Methods("DELETE")
 	r.HandleFunc("/guests/{id}/metadata", chain.GuestRunnerWrapper(getGuestMetadata)).Methods("GET")
 	r.HandleFunc("/guests/{id}/metadata", chain.GuestRunnerWrapper(setGuestMetadata)).Methods("PATCH")


### PR DESCRIPTION
Allow a guest id to be specified on creation. Actually send the jobid header back on guest actions. Add an endpoint to get a specific job's status.