### PR TITLE
MIST-220 cleanup2

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Packege client provides a simple client for the Mistify Agent
+// Package client provides a simple client for the Mistify Agent
 package client
 
 import (
@@ -21,11 +21,12 @@ type (
 		// Scheme is the URI scheme for the Mistify Agent
 		Scheme string
 
-		// HttpClient is the client to use. Default will be
+		// HTTPClient is the client to use. Default will be
 		// used if not provided.
-		HttpClient *http.Client
+		HTTPClient *http.Client
 	}
 
+	// Client for the Mistify Agent
 	Client struct {
 		Config Config
 	}
@@ -36,7 +37,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		Address: "127.0.0.1:8080",
 		Scheme:  "http",
-		HttpClient: &http.Client{
+		HTTPClient: &http.Client{
 			Timeout: time.Duration(5 * time.Second),
 		},
 	}
@@ -54,8 +55,8 @@ func NewClient(config *Config) (*Client, error) {
 		config.Scheme = defConfig.Scheme
 	}
 
-	if config.HttpClient == nil {
-		config.HttpClient = defConfig.HttpClient
+	if config.HTTPClient == nil {
+		config.HTTPClient = defConfig.HTTPClient
 	}
 
 	client := &Client{
@@ -89,7 +90,7 @@ func (c *Client) doRequest(method, path string, input interface{}, expectedStatu
 		return err
 	}
 
-	resp, err := c.Config.HttpClient.Do(req)
+	resp, err := c.Config.HTTPClient.Do(req)
 
 	if err != nil {
 		return err
@@ -107,6 +108,7 @@ func (c *Client) doRequest(method, path string, input interface{}, expectedStatu
 	return err
 }
 
+// ListGuests gets a list of guests
 func (c *Client) ListGuests() (Guests, error) {
 	guests := make(Guests, 0)
 	if err := c.doRequest("GET", "/guests", nil, 200, &guests); err != nil {
@@ -116,6 +118,7 @@ func (c *Client) ListGuests() (Guests, error) {
 	return guests, nil
 }
 
+// GetGuest requests creation of a guest
 func (c *Client) GetGuest(id string) (*Guest, error) {
 	var g Guest
 	if err := c.doRequest("GET", filepath.Join("/guests", id), nil, 200, &g); err != nil {
@@ -124,6 +127,7 @@ func (c *Client) GetGuest(id string) (*Guest, error) {
 	return &g, nil
 }
 
+// CreateGuest requests creation of a new guest
 func (c *Client) CreateGuest(guest *Guest) (*Guest, error) {
 	var g Guest
 	if err := c.doRequest("POST", "/guests", guest, 202, &g); err != nil {

--- a/client/guest.go
+++ b/client/guest.go
@@ -1,6 +1,7 @@
 package client
 
 type (
+	// Guest is a guest virtual machine
 	// +gen * methods:"Where,Each,SortBy" containers:"Set"
 	Guest struct {
 		Id       string            `json:"id"`
@@ -14,6 +15,7 @@ type (
 		Metadata map[string]string `json:"metadata,omitempty"`
 	}
 
+	// Nic is a guest network interface controller
 	Nic struct {
 		Name    string `json:"name,omitempty"`
 		Network string `json:"network"`
@@ -25,6 +27,7 @@ type (
 		Device  string `json:"device,omitempty"`
 	}
 
+	// Disk is a guest storage disk
 	Disk struct {
 		Bus    string `json:"bus"`    // the type of disk device to emulate. "ide", "scsi", "sata", virtio"
 		Device string `json:"device"` // target device inside the guest, ie "vda", "sda", "hda", etc
@@ -34,6 +37,7 @@ type (
 		Source string `json:"source"` // the device name: /dev/zvol/...
 	}
 
+	// GuestDiskMetrics is a set of metrics on a guest's storage disk
 	GuestDiskMetrics struct {
 		Disk       string  `json:"disk"`
 		ReadOps    int64   `json:"read_ops"`
@@ -46,11 +50,13 @@ type (
 		FlushTime  float64 `json:"flush_time"`
 	}
 
+	// GuestCpuMetrics is a set of metrics on a guest's cpu
 	GuestCpuMetrics struct {
 		CpuTime  float64 `json:"cpu_time"`
 		VcpuTime float64 `json:"vcpu_time"`
 	}
 
+	// GuestNicMetrics is a set of metrics on a guests's nic
 	GuestNicMetrics struct {
 		Name      string `json:"name"`
 		RxBytes   int64  `json:"rx_bytes"`

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ type (
 	// ActionType describes synchronicity of an action
 	ActionType int
 
-	// Service is an http service
+	// Service is an HTTP service
 	Service struct {
 		MaxPending uint   `json:"max_pending"`
 		Port       uint   `json:"port"`

--- a/config/config.go
+++ b/config/config.go
@@ -7,25 +7,30 @@ import (
 )
 
 type (
+	// ActionType describes synchronicity of an action
 	ActionType int
 
+	// Service is an http service
 	Service struct {
 		MaxPending uint   `json:"max_pending"`
 		Port       uint   `json:"port"`
 		Path       string `json:"path"`
 	}
 
+	// Stage is a single step for an action
 	Stage struct {
 		Service string            `json:"service"`
 		Method  string            `json:"method"`
 		Args    map[string]string `json:"args"`
 	}
 
+	// Action is a set of stages and how they should be handled
 	Action struct {
 		Type   ActionType
 		Stages []Stage `json:"stages"`
 	}
 
+	// Config contains all of the configuration data
 	Config struct {
 		Actions  map[string]Action  `json:"actions"`
 		Services map[string]Service `json:"services"`
@@ -34,14 +39,17 @@ type (
 )
 
 const (
+	// InfoAction is for synchronous information retrieval in JSON format
 	InfoAction ActionType = iota
+	// StreamAction is for synchronous data streaming
 	StreamAction
+	// AsyncAction is for asynchronous actions
 	AsyncAction
 )
 
 var (
-	// Valid actions and their associated type
-	ValidActions map[string]ActionType = map[string]ActionType{
+	// ValidActions is a whitelist of configurable actions and their types
+	ValidActions = map[string]ActionType{
 		"create":           AsyncAction,
 		"delete":           AsyncAction,
 		"reboot":           AsyncAction,
@@ -65,6 +73,7 @@ var (
 	}
 )
 
+// NewConfig creates a new Config
 func NewConfig() *Config {
 	c := &Config{
 		Actions:  make(map[string]Action),
@@ -88,6 +97,7 @@ func (stage *Stage) validate(prefix string) error {
 	return nil
 }
 
+// AddConfig loads a configuration file
 func (c *Config) AddConfig(path string) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -136,6 +146,7 @@ func (c *Config) AddConfig(path string) error {
 	return nil
 }
 
+// Fixup does a bit of validation and initializtion
 func (c *Config) Fixup() error {
 	for name, action := range c.Actions {
 		for _, stage := range action.Stages {

--- a/examples/simple-subagent/main.go
+++ b/examples/simple-subagent/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 type (
+	// Simple is the basic struct for the simple service
 	Simple struct {
 		rand    *rand.Rand // random number generator
 		percent int        // how often to return an error

--- a/examples/simple-subagent/main.go
+++ b/examples/simple-subagent/main.go
@@ -61,7 +61,12 @@ func main() {
 		}).Fatal(err)
 	}
 
-	server.RegisterService(&s)
+	if err := server.RegisterService(&s); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"func":  "rpc.Server.RegisterService",
+		}).Fatal(err)
+	}
 	if err = server.ListenAndServe(); err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/examples/test-rpc-service/main.go
+++ b/examples/test-rpc-service/main.go
@@ -260,7 +260,12 @@ func main() {
 	}
 
 	test := &Test{}
-	s.RegisterService(test)
+	if err := s.RegisterService(test); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"func":  "rpc.Server.RegisterService",
+		}).Fatal(err)
+	}
 	s.HandleFunc("/snapshots/download", test.DownloadSnapshot)
 	if err = s.ListenAndServe(); err != nil {
 		log.WithFields(log.Fields{

--- a/examples/test-rpc-service/main.go
+++ b/examples/test-rpc-service/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 type (
+	// Test is the basic struct for the test service
 	Test struct {
 	}
 )
@@ -76,7 +77,7 @@ func (t *Test) Shutdown(r *http.Request, request *rpc.GuestRequest, response *rp
 	return nil
 }
 
-// Retrieve CPU metrics.  Currently, only one sub-agent service is called for this.
+// CpuMetrics retrieves CPU metrics.  Currently, only one sub-agent service is called for this.
 func (t *Test) CpuMetrics(r *http.Request, request *rpc.GuestMetricsRequest, response *rpc.GuestMetricsResponse) error {
 	*response = rpc.GuestMetricsResponse{
 		Guest: request.Guest,
@@ -88,7 +89,7 @@ func (t *Test) CpuMetrics(r *http.Request, request *rpc.GuestMetricsRequest, res
 	return nil
 }
 
-// Retrieve Disk metrics.  Currently, only one sub-agent service is called for this.
+// DiskMetrics retrieves Disk metrics.  Currently, only one sub-agent service is called for this.
 func (t *Test) DiskMetrics(r *http.Request, request *rpc.GuestMetricsRequest, response *rpc.GuestMetricsResponse) error {
 	*response = rpc.GuestMetricsResponse{
 		Guest: request.Guest,
@@ -102,7 +103,7 @@ func (t *Test) DiskMetrics(r *http.Request, request *rpc.GuestMetricsRequest, re
 	return nil
 }
 
-// Retrieve Network metrics.  Currently, only one sub-agent service is called for this.
+// NicMetrics retrieves Network metrics.  Currently, only one sub-agent service is called for this.
 func (t *Test) NicMetrics(r *http.Request, request *rpc.GuestMetricsRequest, response *rpc.GuestMetricsResponse) error {
 	*response = rpc.GuestMetricsResponse{
 		Guest: request.Guest,
@@ -116,6 +117,7 @@ func (t *Test) NicMetrics(r *http.Request, request *rpc.GuestMetricsRequest, res
 	return nil
 }
 
+// ListImages lists disk images
 func (t *Test) ListImages(r *http.Request, request *rpc.ImageRequest, response *rpc.ImageResponse) error {
 	*response = rpc.ImageResponse{
 		Images: []*rpc.Image{
@@ -131,6 +133,7 @@ func (t *Test) ListImages(r *http.Request, request *rpc.ImageRequest, response *
 	return nil
 }
 
+// GetImage retrieves a disk image
 func (t *Test) GetImage(r *http.Request, request *rpc.ImageRequest, response *rpc.ImageResponse) error {
 	*response = rpc.ImageResponse{
 		Images: []*rpc.Image{
@@ -146,6 +149,7 @@ func (t *Test) GetImage(r *http.Request, request *rpc.ImageRequest, response *rp
 	return nil
 }
 
+// DeleteImage deletes a disk image
 func (t *Test) DeleteImage(r *http.Request, request *rpc.ImageRequest, response *rpc.ImageResponse) error {
 	*response = rpc.ImageResponse{
 		Images: []*rpc.Image{
@@ -161,6 +165,7 @@ func (t *Test) DeleteImage(r *http.Request, request *rpc.ImageRequest, response 
 	return nil
 }
 
+// RequestImage requests the fetching of a new images
 func (t *Test) RequestImage(r *http.Request, request *rpc.ImageRequest, response *rpc.ImageResponse) error {
 	*response = rpc.ImageResponse{
 		Images: []*rpc.Image{
@@ -176,6 +181,7 @@ func (t *Test) RequestImage(r *http.Request, request *rpc.ImageRequest, response
 	return nil
 }
 
+// ListSnapshots retrieves a list of snapshots
 func (t *Test) ListSnapshots(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
 	*response = rpc.SnapshotResponse{
 		Snapshots: []*rpc.Snapshot{
@@ -188,6 +194,7 @@ func (t *Test) ListSnapshots(r *http.Request, request *rpc.SnapshotRequest, resp
 	return nil
 }
 
+// GetSnapshot gets a single snapshot
 func (t *Test) GetSnapshot(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
 	*response = rpc.SnapshotResponse{
 		Snapshots: []*rpc.Snapshot{
@@ -200,6 +207,7 @@ func (t *Test) GetSnapshot(r *http.Request, request *rpc.SnapshotRequest, respon
 	return nil
 }
 
+// CreateSnapshot creates a new snapshot
 func (t *Test) CreateSnapshot(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
 	*response = rpc.SnapshotResponse{
 		Snapshots: []*rpc.Snapshot{
@@ -212,6 +220,7 @@ func (t *Test) CreateSnapshot(r *http.Request, request *rpc.SnapshotRequest, res
 	return nil
 }
 
+// DeleteSnapshot deletes a snapshot
 func (t *Test) DeleteSnapshot(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
 	*response = rpc.SnapshotResponse{
 		Snapshots: []*rpc.Snapshot{
@@ -224,6 +233,7 @@ func (t *Test) DeleteSnapshot(r *http.Request, request *rpc.SnapshotRequest, res
 	return nil
 }
 
+// RollbackSnapshot rolls the filesystem back to a snapshot
 func (t *Test) RollbackSnapshot(r *http.Request, request *rpc.SnapshotRequest, response *rpc.SnapshotResponse) error {
 	*response = rpc.SnapshotResponse{
 		Snapshots: []*rpc.Snapshot{
@@ -236,6 +246,7 @@ func (t *Test) RollbackSnapshot(r *http.Request, request *rpc.SnapshotRequest, r
 	return nil
 }
 
+// DownloadSnapshot downloads a snapshot via streaming
 func (t *Test) DownloadSnapshot(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	fmt.Fprint(w, "foobar")

--- a/examples/webhook-post/main.go
+++ b/examples/webhook-post/main.go
@@ -116,7 +116,12 @@ func main() {
 			Timeout: time.Second * 5,
 		},
 	}
-	s.RegisterService(w)
+	if err := s.RegisterService(w); err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"func":  "rpc.Server.RegisterService",
+		}).Fatal(err)
+	}
 	if err = s.ListenAndServe(); err != nil {
 		log.WithFields(log.Fields{
 			"error": err,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -13,7 +13,7 @@ import (
 type (
 	// Client is a simple JSON-RPC over HTTP client used by the agent.
 	Client struct {
-		Url string
+		URL string
 	}
 )
 
@@ -24,7 +24,7 @@ func NewClient(port uint, path string) (*Client, error) {
 	}
 	c := &Client{
 		//XXX: this seems wrong
-		Url: fmt.Sprintf("http://127.0.0.1:%d%s", port, path),
+		URL: fmt.Sprintf("http://127.0.0.1:%d%s", port, path),
 	}
 	return c, nil
 }
@@ -35,7 +35,7 @@ func (c *Client) Do(method string, request interface{}, response interface{}) er
 	if err != nil {
 		return err
 	}
-	resp, err := http.Post(c.Url, "application/json", bytes.NewReader(data))
+	resp, err := http.Post(c.URL, "application/json", bytes.NewReader(data))
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (c *Client) DoRaw(request interface{}, rw http.ResponseWriter) {
 		http.Error(rw, err.Error(), 500)
 		return
 	}
-	resp, err := http.Post(c.Url, "application/json", bytes.NewReader(data))
+	resp, err := http.Post(c.URL, "application/json", bytes.NewReader(data))
 	if err != nil {
 		http.Error(rw, err.Error(), 500)
 		return

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -64,7 +64,10 @@ func (c *Client) DoRaw(request interface{}, rw http.ResponseWriter) {
 
 	if resp.StatusCode != 200 {
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
+		if _, err := buf.ReadFrom(resp.Body); err != nil {
+			http.Error(rw, err.Error(), 500)
+			return
+		}
 		http.Error(rw, buf.String(), resp.StatusCode)
 		return
 	}

--- a/rpc/guest.go
+++ b/rpc/guest.go
@@ -12,18 +12,21 @@ type (
 		Args   map[string]string `json:"args,omitempty"` // Opaque, optional arguments
 	}
 
+	// GuestResponse is a response from a sub-agent
 	GuestResponse struct {
 		Guest   *client.Guest `json:"guest"`             // Guest, possibly modified
 		Message string        `json:"message,omitempty"` // Any informational message
 		Retry   int           `json:"retry,omitempty"`   // instruct the agent to retry after this many second. Not yet implemented
 	}
 
+	// GuestMetricsRequest is a request for guest metrics
 	GuestMetricsRequest struct {
 		Guest *client.Guest     `json:"guest"`          // Guest
 		Type  string            `json:"type"`           // type of metric desired
 		Args  map[string]string `json:"args,omitempty"` // Opaque, optional arguments
 	}
 
+	// GuestMetricsResponse is a response of guest metrics
 	GuestMetricsResponse struct {
 		Guest *client.Guest                       `json:"guest"`          // Guest - in general this should not be modified
 		Type  string                              `json:"type"`           // Type of metrics returned

--- a/rpc/image.go
+++ b/rpc/image.go
@@ -20,7 +20,7 @@ type (
 		Device string `json:"device"` // Device in /dev to use
 	}
 
-	// Volume represents a ZFS Snapshot
+	// Snapshot represents a ZFS Snapshot
 	Snapshot struct {
 		Id   string `json:"id"`   // Unique ID
 		Size uint64 `json:"size"` // Size in MB
@@ -33,7 +33,7 @@ type (
 		Source string `json:"source"` // Source for fetches. Generally a URL
 	}
 
-	// ImageRequest is an image response from the Storage sub-agent
+	// ImageResponse is an image response from the Storage sub-agent
 	ImageResponse struct {
 		Images []*Image `json:"images"` //Image slice for gets and lists. An empty slice is generally used for "not found"
 	}
@@ -57,6 +57,7 @@ type (
 		DestroyMoreRecent bool   `json:"destroyMoreRecent"` // Destroy more recent snapshots when rolling back
 	}
 
+	// SnapshotResponse is a snapshot response for the Storage sub-agent
 	SnapshotResponse struct {
 		Snapshots []*Snapshot `json:"snapshots"` // Snapshot slice for gets and lists. An empty slice is generally used for "not found"
 	}

--- a/rpc/logger.go
+++ b/rpc/logger.go
@@ -96,6 +96,6 @@ func (l *logger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	b.WriteString("\n")
-	b.WriteTo(l.writer)
+	_, _ = b.WriteString("\n")
+	_, _ = b.WriteTo(l.writer)
 }

--- a/rpc/logger.go
+++ b/rpc/logger.go
@@ -35,7 +35,7 @@ type (
 	}
 )
 
-func NewLogger(w io.Writer, h http.Handler) *logger {
+func newLogger(w io.Writer, h http.Handler) *logger {
 	return &logger{
 		writer:  w,
 		handler: h,

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -14,15 +14,18 @@ const (
 	RPCPath = "/_mistify_RPC_"
 )
 
+// Codec is a wrapper for the json.Codec
 type Codec struct {
 	*json.Codec
 }
 
+// NewCodec creates a new Codec
 func NewCodec() *Codec {
 	c := json.NewCodec()
 	return &Codec{c}
 }
 
+// NewRequest creates a new request from the codec
 func (c *Codec) NewRequest(r *http.Request) rpc.CodecRequest {
 	cr := c.Codec.NewRequest(r)
 


### PR DESCRIPTION
Known errcheck complaints, intentionally ignored:
```
github.com/mistifyio/mistify-agent/client/client.go:99:23	defer resp.Body.Close()
github.com/mistifyio/mistify-agent/examples/webhook-post/main.go:82:17	resp.Body.Close()
github.com/mistifyio/mistify-agent/rpc/client.go:42:23	defer resp.Body.Close()
github.com/mistifyio/mistify-agent/rpc/client.go:63:23	defer resp.Body.Close()
```

Known golint complaints:
- Id vs ID and Cpu vs CPU struct fields: Will require more careful and coordinated changing with other repos. Going to do so separately
- client/guest_container.go comments : being addressed in https://github.com/clipperhouse/set/pull/3 and will be regenerated once merged.