### PR TITLE
MIST-286 Handle error responses in the RPC Client.Do method

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,6 +41,14 @@ func (c *Client) Do(method string, request interface{}, response interface{}) er
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		buf := new(bytes.Buffer)
+		if _, err := buf.ReadFrom(resp.Body); err != nil {
+			return err
+		}
+		return errors.New(buf.String())
+	}
 
 	err = rpcJSON.DecodeClientResponse(resp.Body, &response)
 	if err != nil {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -42,8 +42,8 @@ func (c *Client) Do(method string, request interface{}, response interface{}) er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode >= 400 {
-		buf := new(bytes.Buffer)
+	if resp.StatusCode >= http.StatusBadRequest {
+		var buf bytes.Buffer
 		if _, err := buf.ReadFrom(resp.Body); err != nil {
 			return err
 		}


### PR DESCRIPTION
In most of the error cases, subagents will return an error HTTP status
code along with a string body message. Client.Do was expecting all
responses to be JSON and tripped when trying to decode the non-JSON
error string. That replaced the real error with a JSON decoding error,
losing the original message.

Instead, read out the body message and make it into an Error when the
HTTP status is in the error range (>= 400)