### PR TITLE
Removed the change owner to root. This is not allowed when installing to

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 	go clean
 
 install_config:
-	install -D -m 0444 -o root cmd/mistify-agent/agent.json $(DESTDIR)$(CONF_DIR)/agent.json
+	install -D -m 0444 cmd/mistify-agent/agent.json $(DESTDIR)$(CONF_DIR)/agent.json
 
 install: cmd/mistify-agent/mistify-agent install_config
 	install -D cmd/mistify-agent/mistify-agent $(DESTDIR)$(SBIN_DIR)/mistify-agent


### PR DESCRIPTION
the target file system. Buildroot will change ownership when creating the
rootfs image.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent/40)
<!-- Reviewable:end -->
