### PR TITLE
MIST-286 Default port of mistify-agent-image is 19999, not 16000

### DIFF
--- a/cmd/mistify-agent/agent.json
+++ b/cmd/mistify-agent/agent.json
@@ -274,11 +274,11 @@
             "port": 30001
         },
         "storage": {
-            "port": 16000
+            "port": 19999
         },
         "storageDownload": {
             "path": "/snapshots/download",
-            "port": 16000
+            "port": 19999
         }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent/41)
<!-- Reviewable:end -->
