### PR TITLE
MIST-384 PreStageFunc and PostStageFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,11 +542,13 @@ JobStatus is the string status of a job
 
 ```go
 type Pipeline struct {
-	ID       string
-	Action   string
-	Type     config.ActionType
-	Stages   []*Stage
-	DoneChan chan error // Signal async is done or errored, for post-hooks
+	ID            string
+	Action        string
+	Type          config.ActionType
+	Stages        []*Stage
+	PreStageFunc  func(*Pipeline, *Stage) error
+	PostStageFunc func(*Pipeline, *Stage) error
+	DoneChan      chan error // Signal async is done or errored, for post-hooks
 }
 ```
 

--- a/guest.go
+++ b/guest.go
@@ -130,12 +130,12 @@ func createGuest(r *HTTPRequest) *HTTPErrorMessage {
 		Action: action.Name,
 	}
 	pipeline := action.GeneratePipeline(request, response, r.ResponseWriter, nil)
-	// PreStageFunc to populate copy the stage args into the request
+	// PreStageFunc copies the stage args into the request
 	pipeline.PreStageFunc = func(p *Pipeline, s *Stage) error {
 		request.Args = s.Args
 		return nil
 	}
-	// PostStageFunc to update guest in request and persist guest
+	// PostStageFunc saves the guest and uses it for the next request
 	pipeline.PostStageFunc = func(p *Pipeline, s *Stage) error {
 		request.Guest = response.Guest
 		return r.Context.PersistGuest(response.Guest)
@@ -272,12 +272,12 @@ func (c *Chain) GuestActionWrapper(actionName string) http.HandlerFunc {
 		}
 		doneChan := make(chan error)
 		pipeline := action.GeneratePipeline(request, response, r.ResponseWriter, doneChan)
-		// PreStageFunc to populate copy the stage args into the request
+		// PreStageFunc copies the stage args into the request
 		pipeline.PreStageFunc = func(p *Pipeline, s *Stage) error {
 			request.Args = s.Args
 			return nil
 		}
-		// PostStageFunc to update guest in request and persist guest
+		// PostStageFunc saves the guest and uses it for the next request
 		pipeline.PostStageFunc = func(p *Pipeline, s *Stage) error {
 			request.Guest = response.Guest
 			return r.Context.PersistGuest(response.Guest)

--- a/guest.go
+++ b/guest.go
@@ -123,17 +123,24 @@ func createGuest(r *HTTPRequest) *HTTPErrorMessage {
 	if err != nil {
 		return r.NewError(err, http.StatusNotFound)
 	}
+
 	response := &rpc.GuestResponse{}
-	pipeline := action.GeneratePipeline(nil, response, r.ResponseWriter, nil)
-	// Guest requests are special in that they have Args and need
-	// the action name, so fold them in to the request
-	for _, stage := range pipeline.Stages {
-		stage.Request = &rpc.GuestRequest{
-			Guest:  g,
-			Args:   stage.Args,
-			Action: action.Name,
-		}
+	request := &rpc.GuestRequest{
+		Guest:  g,
+		Action: action.Name,
 	}
+	pipeline := action.GeneratePipeline(request, response, r.ResponseWriter, nil)
+	// PreStageFunc to populate copy the stage args into the request
+	pipeline.PreStageFunc = func(p *Pipeline, s *Stage) error {
+		request.Args = s.Args
+		return nil
+	}
+	// PostStageFunc to update guest in request and persist guest
+	pipeline.PostStageFunc = func(p *Pipeline, s *Stage) error {
+		request.Guest = response.Guest
+		return r.Context.PersistGuest(response.Guest)
+	}
+
 	r.ResponseWriter.Header().Set("X-Guest-Job-ID", pipeline.ID)
 	err = runner.Process(pipeline)
 	if err != nil {
@@ -259,17 +266,23 @@ func (c *Chain) GuestActionWrapper(actionName string) http.HandlerFunc {
 		}
 
 		response := &rpc.GuestResponse{}
-		doneChan := make(chan error)
-		pipeline := action.GeneratePipeline(nil, response, r.ResponseWriter, doneChan)
-		// Guest requests are special in that they have Args and need
-		// the action name, so fold them in to the request
-		for _, stage := range pipeline.Stages {
-			stage.Request = &rpc.GuestRequest{
-				Guest:  g,
-				Args:   stage.Args,
-				Action: action.Name,
-			}
+		request := &rpc.GuestRequest{
+			Guest:  g,
+			Action: action.Name,
 		}
+		doneChan := make(chan error)
+		pipeline := action.GeneratePipeline(request, response, r.ResponseWriter, doneChan)
+		// PreStageFunc to populate copy the stage args into the request
+		pipeline.PreStageFunc = func(p *Pipeline, s *Stage) error {
+			request.Args = s.Args
+			return nil
+		}
+		// PostStageFunc to update guest in request and persist guest
+		pipeline.PostStageFunc = func(p *Pipeline, s *Stage) error {
+			request.Guest = response.Guest
+			return r.Context.PersistGuest(response.Guest)
+		}
+
 		r.ResponseWriter.Header().Set("X-Guest-Job-ID", pipeline.ID)
 		err = runner.Process(pipeline)
 		if err != nil {
@@ -289,9 +302,6 @@ func (c *Chain) GuestActionWrapper(actionName string) http.HandlerFunc {
 						"func":  "agent.Context.DeleteGuest",
 					}).Error("Delete Error:", err)
 				}
-				return
-			}
-			if err := r.Context.PersistGuest(g); err != nil {
 				return
 			}
 		}()


### PR DESCRIPTION
Add PreStageFunc and PostStageFunc to provide a way to perform work before and/or after every stage in a pipeline if set. Use PreStageFunc to set the request args for the stage in a guest action. Use PostStageFunc to update the guest in the request and persist the guest based on the response in a guest action.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent/47)
<!-- Reviewable:end -->
